### PR TITLE
Show search terms on empty result message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Update 'no results' message on search with terms and update the `q` query
+argument with the new terms.
 - Reduce required account longevity to 3 months.
 
 ## [21.2.5] - 2021-05-05

--- a/apps/shoutouts_web/lib/shoutouts_web/live/search_live/search_component.ex
+++ b/apps/shoutouts_web/lib/shoutouts_web/live/search_live/search_component.ex
@@ -1,47 +1,8 @@
 defmodule ShoutoutsWeb.SearchLive.SearchComponent do
   @moduledoc """
-  Live component showing results.
+  Live component showing form and results.
   """
   use ShoutoutsWeb, :live_component
+  # used in template
   alias Shoutouts.Projects
-
-  require Logger
-
-  def mount(socket) do
-    {:ok,
-     socket
-     |> assign(:current_user_id, nil)
-     |> assign(:terms, "")
-     |> assign(:results, [])}
-  end
-
-  def update(%{terms: "", current_user_id: current_user_id} = _assigns, socket) do
-    socket =
-      socket
-      |> assign(:current_user_id, current_user_id)
-      |> assign(:terms, "")
-      |> assign(:results, [])
-
-    {:ok, socket}
-  end
-
-  def update(%{terms: terms, current_user_id: current_user_id}, socket) do
-    socket =
-      socket
-      |> assign(:current_user_id, current_user_id)
-      |> assign(:terms, terms)
-      |> assign(:results, do_search(terms))
-
-    {:ok, socket}
-  end
-
-  defp do_search(terms) do
-    Logger.debug("Searching for `#{terms}`")
-    terms = String.trim(terms)
-
-    case Regex.match?(~r/^[\w\s\/-]{2,50}$/, terms) do
-      true -> Projects.search(terms)
-      false -> []
-    end
-  end
 end

--- a/apps/shoutouts_web/lib/shoutouts_web/live/search_live/search_component.html.leex
+++ b/apps/shoutouts_web/lib/shoutouts_web/live/search_live/search_component.html.leex
@@ -3,7 +3,7 @@
   </form>
 
   <%= if @terms != "" and length(@results) == 0 do %>
-    <div class="text-2xl text-center text-gray-800 font-sans mb-8">Sorry, no projects match your query</div>
+    <div class="text-2xl text-center text-gray-800 font-sans mb-8">Sorry, no projects match "<%= @terms %>"</div>
     <div class="text-xl text-center text-primary font-sans mb-4">Would you like to register the project and leave a shoutout?</div>
     <div class="text-center">
     <%= if @current_user_id == nil do %>

--- a/apps/shoutouts_web/lib/shoutouts_web/live/search_live/show.ex
+++ b/apps/shoutouts_web/lib/shoutouts_web/live/search_live/show.ex
@@ -1,39 +1,60 @@
 defmodule ShoutoutsWeb.SearchLive.Show do
+  @moduledoc """
+  Search LiveView. The `q` query parameter drives the search, if it is missing
+  we display a summary of the top projects by language.
+
+  The SearchLive.SearchComponent displays the form and the results.
+  """
   use ShoutoutsWeb, :live_view
   alias Shoutouts.Projects
 
   require Logger
 
-  @doc """
-  Query arg terms.
-  """
-  def mount(%{"q" => terms}, session, socket) do
+  def mount(params, session, socket) do
     summary = Projects.summary_by_languages(6, 5)
+    {terms, results} = parse_params(params)
 
     {:ok,
      socket
      |> assign(:page_title, "Search")
      |> assign(:current_user_id, Map.get(session, "current_user_id"))
      |> assign(:terms, terms)
+     |> assign(:results, results)
      |> assign(:summary, summary)}
   end
 
-  # No query arg entry point.
-  def mount(_params, session, socket) do
-    summary = Projects.summary_by_languages(6, 5)
-
-    {:ok,
-     socket
-     |> assign(:page_title, "Search")
-     |> assign(:current_user_id, Map.get(session, "current_user_id"))
-     |> assign(:terms, "")
-     |> assign(:summary, summary)}
+  def handle_event("search", params, socket) do
+    path = case params do
+      %{"q" => ""} -> Routes.search_show_path(socket, :index)
+      %{"q" => terms} -> Routes.search_show_path(socket, :index, q: terms)
+    end
+    {:noreply, push_patch(socket, to: path)}
   end
 
-  # The event payload will usually be the event itself, except for forms.
-  def handle_event("search", %{"q" => terms}, socket) do
+  def handle_params(params, _uri, socket) do
+    {terms, results} = parse_params(params)
+
     {:noreply,
      socket
-     |> assign(:terms, terms)}
+     |> assign(:terms, terms)
+     |> assign(:results, results)}
+  end
+
+  defp parse_params(params) do
+    case params do
+      %{"q" => ""} -> {"", []}
+      %{"q" => terms} -> {terms, do_search(terms)}
+      _ -> {"", []}
+    end
+  end
+
+  defp do_search(terms) do
+    Logger.debug("Searching for `#{terms}`")
+    terms = String.trim(terms)
+
+    case Regex.match?(~r/^[\w\s\/-]{2,50}$/, terms) do
+      true -> Projects.search(terms)
+      false -> []
+    end
   end
 end

--- a/apps/shoutouts_web/lib/shoutouts_web/live/search_live/show.html.leex
+++ b/apps/shoutouts_web/lib/shoutouts_web/live/search_live/show.html.leex
@@ -9,7 +9,7 @@
     </h2>
   </div>
 
-  <%= live_component @socket, ShoutoutsWeb.SearchLive.SearchComponent, terms: @terms, id: :search, current_user_id: @current_user_id %>
+  <%= live_component @socket, ShoutoutsWeb.SearchLive.SearchComponent, terms: @terms, results: @results, id: :search, current_user_id: @current_user_id %>
 
   <%= if @terms == "" do %> 
   <div>

--- a/apps/shoutouts_web/test/shoutouts_web/live/search_live_test.exs
+++ b/apps/shoutouts_web/test/shoutouts_web/live/search_live_test.exs
@@ -14,7 +14,7 @@ defmodule ShoutoutsWeb.SearchLiveTest do
 
   test "renders no projects if not match on query arg term", %{conn: conn} do
     {:ok, _view, html} = live(conn, Routes.search_show_path(conn, :index, %{q: "foo"}))
-    assert html =~ "Sorry, no projects match your query"
+    assert html =~ "Sorry, no projects match &quot;foo&quot;"
   end
 
   test "renders projects matching the query arg term", %{conn: conn} do


### PR DESCRIPTION
Updates the `q` query argument as terms change.

Closes #76 