### PR TITLE
Move release version to rel/config.exs to speed up releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## Unreleased
 
-- Add "write a shoutout" CTA to home page
+- Add "write a shoutout" CTA to home page.
+- Move release version to rel/config.exs to speed up release process.
 
 ## [21.3.0] - 2021-05-18
 

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ these should be change together to avoid confusion.
 
 Pre-release checklist:
 
-- Bump the version, we use a CalVer YY.MAJOR.MINOR
+- Bump the version in `rel/config.exs`, we use a CalVer YY.MAJOR.MINOR
 - Test the app using `make prod-server` to ensure production assets are correct.
 - Run `make mac-release` to create a Mac release and test locally via Distillery
 commands.

--- a/apps/shoutouts/mix.exs
+++ b/apps/shoutouts/mix.exs
@@ -4,7 +4,8 @@ defmodule Shoutouts.MixProject do
   def project do
     [
       app: :shoutouts,
-      version: "21.3.0",
+      # Fixed version, the actualy one is defined in rel/config.exs
+      version: "1.0.0",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",

--- a/apps/shoutouts_web/lib/shoutouts_web/controllers/auth_controller.ex
+++ b/apps/shoutouts_web/lib/shoutouts_web/controllers/auth_controller.ex
@@ -28,6 +28,7 @@ defmodule ShoutoutsWeb.AuthController do
     |> put_session(:redirect_to, redirect_target(conn))
     |> Ueberauth.run_request(provider_name, get_provider_config())
   end
+
   def request(
         %{assigns: %{current_user_id: _}} = conn,
         _params

--- a/apps/shoutouts_web/mix.exs
+++ b/apps/shoutouts_web/mix.exs
@@ -4,7 +4,8 @@ defmodule ShoutoutsWeb.MixProject do
   def project do
     [
       app: :shoutouts_web,
-      version: "21.3.0",
+      # Fixed version, the actualy one is defined in rel/config.exs
+      version: "1.0.0",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",

--- a/rel/config.exs
+++ b/rel/config.exs
@@ -46,7 +46,7 @@ end
 # will be used by default
 
 release :shoutouts_umbrella do
-  set(version: current_version(:shoutouts))
+  set(version: "21.3.0")
 
   set(
     applications: [


### PR DESCRIPTION
Having the release version in the mix.exs meant the Dockerfile cache would invalidate at the installing dependencies line which requires a full download and recompile on every release